### PR TITLE
Add multi-route scraping support for Camino Navarro and Camino Francés

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Pilgrim Stamp Scraper
 
-A Python web scraper for extracting pilgrim stamp locations from the Camino Navarro website.
+A Python web scraper for extracting pilgrim stamp locations from multiple Camino routes including Camino Navarro and Camino Francés.
 
 ## Project Overview
 
-This project scrapes the website https://www.lossellosdelcamino.com to extract information about pilgrim stamp locations along the Camino Navarro route. It systematically navigates through town pages and stamp location pages to collect data and download stamp images.
+This project scrapes the website https://www.lossellosdelcamino.com to extract information about pilgrim stamp locations along multiple Camino routes. It systematically navigates through town pages and stamp location pages to collect data and download stamp images for both the Navarrese Way and the full French Way.
 
 ## Features
 
-- Scrapes main page for town category links
-- Extracts stamp location links from each town
+- Scrapes multiple Camino routes (Navarrese and French Ways)
+- Scrapes main page for town category links per route
+- Extracts stamp location links from each town per route
 - Downloads stamp images locally
-- Organizes data into structured format
-- Exports results to Excel file
+- Organizes data into structured format with route identification
+- Exports results to Excel file with comprehensive multi-route data
 
 ## Project Structure
 
@@ -60,4 +61,4 @@ The scraper produces:
 
 ## Status
 
-This project is currently under development with planned subtasks for implementation.
+This project now supports multi-route scraping for both Camino Navarro and Camino Francés routes. The scraper automatically processes both routes sequentially and provides comprehensive statistics for each route.


### PR DESCRIPTION
This commit implements comprehensive multi-route scraping functionality. The PilgrimStampScraper class now accepts a route parameter to handle both Navarrese and French Ways. The main execution loop processes both routes sequentially, collecting data from each route and compiling comprehensive statistics. Key changes include dynamic URL construction based on route type, route-specific pattern matching for town and stamp location extraction, and enhanced logging with route identification. The final summary now provides detailed breakdowns for each route including stamp location counts, town counts, and success rate analysis. This enables collection of pilgrim stamp data from the entire Camino Francés route rather than just the Navarrese section.